### PR TITLE
fix: error: failed to compile airmail_indexer v0.1.0

### DIFF
--- a/airmail_indexer/Dockerfile
+++ b/airmail_indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76
+FROM rust:1.81
 
 RUN apt-get update && apt-get install -y libssl-dev capnproto clang pkg-config libzstd-dev libsqlite3-mod-spatialite && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This fixes
```
error: failed to compile `airmail_indexer v0.1.0 (/usr/src/airmail/airmail_indexer)`, intermediate artifacts can be found at `/usr/src/airmail/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  package `home v0.5.11` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.76.0
```