### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76 as build
+FROM rust:1.81 as build
 
 RUN apt update && apt install -y libssl-dev clang pkg-config
 

--- a/airmail_indexer/Dockerfile.osmx
+++ b/airmail_indexer/Dockerfile.osmx
@@ -14,7 +14,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 WORKDIR /usr/src/
 RUN git clone --recurse-submodules https://github.com/protomaps/OSMExpress.git
 WORKDIR /usr/src/OSMExpress
-RUN git checkout 24cdc6cca55f45b4019e2d490c2321c366ca3362
+RUN git checkout 331020a9e027c42c29baa423adeb726332ca2105
 
 
 RUN cmake -DCMAKE_BUILD_TYPE=Release .


### PR DESCRIPTION
Fixes #29 

Update to a newer version of OSMExpress.
Use a newer rust version.