### PR TITLE
runs cargo --locked to resolve crate errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./airmail_service ./airmail_service
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 
-RUN cargo install --path ./airmail_service
+RUN cargo install --locked --path ./airmail_service
 
 WORKDIR /app
 

--- a/airmail_indexer/Dockerfile
+++ b/airmail_indexer/Dockerfile
@@ -9,6 +9,6 @@ COPY ./airmail_service ./airmail_service
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 
-RUN cargo install --path ./airmail_indexer
+RUN cargo install --locked --path ./airmail_indexer
 
 WORKDIR /var/airmail


### PR DESCRIPTION
I was finding that building the docker images was failing, due to crate build errors like [this one](https://github.com/RustCrypto/formats/issues/1684) that appear to be related to the Rust version or featureset. I'm not a Rust developer — so it's possible it's worth resolving these errors directly — but pinning the dependencies to the lockfile appeared resolved the errors for me, so I figured I would submit a patch!

(Airmail is really cool, by the way!)